### PR TITLE
Split up action selection and moving from updating agent and made people move less during working day

### DIFF
--- a/covid-sim.nlogo
+++ b/covid-sim.nlogo
@@ -121,6 +121,10 @@ to perform-people-activities
   ask people [
     perform-activity
   ]
+  ask people [
+    execute-activity-effect
+    update-needs-for-playing (list current-activity current-motivation)
+  ]
   if animate? [
     let walkers people with [pxcor != [pxcor] of current-activity or pycor != [pycor] of current-activity]
     while [any? walkers] [
@@ -882,7 +886,7 @@ probability-school-personel
 probability-school-personel
 0
 1
-0.36
+0.35
 0.01
 1
 NIL
@@ -972,7 +976,7 @@ SWITCH
 57
 animate?
 animate?
-1
+0
 1
 -1000
 
@@ -1032,7 +1036,7 @@ SWITCH
 57
 debug?
 debug?
-1
+0
 1
 -1000
 
@@ -1645,7 +1649,7 @@ SWITCH
 94
 with-infected?
 with-infected?
-0
+1
 1
 -1000
 

--- a/need_management.nls
+++ b/need_management.nls
@@ -149,13 +149,22 @@ to-report expected-undiscounted-compliance-needs-satisfaction-increase-for-playi
   if (motive = "contractual obligation") and is-I-have-contractual-obligations?
   [
 ;    show "do your work bonus"
-    if not is-lockdown-enforced? and  gp != my-home
-    [set bonus-compliance-to-obligation bonus-compliance-to-obligation + 0.1]
+    if not is-lockdown-enforced? and gp != my-home [
+      set bonus-compliance-to-obligation bonus-compliance-to-obligation + 0.2
+      if gp = current-activity [
+        set bonus-compliance-to-obligation  bonus-compliance-to-obligation + 0.1
+      ]
+    ]
     set bonus-compliance-to-obligation  bonus-compliance-to-obligation + 0.1
   ]
+  if is-I-have-contractual-obligations? and motive != "contractual obligation" [
+    set bonus-compliance-to-obligation bonus-compliance-to-obligation - 0.2
+  ]
   
-  if (motive = "mandatory") and not is-lockdown-enforced? [
+  ifelse (motive = "mandatory") and not is-lockdown-enforced? [
     set bonus-compliance-to-obligation bonus-compliance-to-obligation + 0.1
+  ] [
+    set bonus-compliance-to-obligation bonus-compliance-to-obligation - 0.1
   ]
   
   if (motive = "learning") and not is-lockdown-enforced? [
@@ -229,7 +238,7 @@ to-report expected-undiscounted-autonomy-needs-satisfaction-increase-for-playing
       ifelse motive = "contractual obligation" [
         ifelse gp != my-home
         [ report 0.2 ]
-        [ report 0.1 ]
+        [ report 0.05 ]
       ]
       [ report -0.1 ]
     ]

--- a/need_management.nls
+++ b/need_management.nls
@@ -5,7 +5,7 @@ to update-needs-for-playing [current-activity-descriptor]
   decay-need-satisfaction
   
   set belonging-need-satisfaction
-  belonging-need-satisfaction + my-expected-discounted-satisfaction-gain-for-belonging-needs-after-having-played current-activity-descriptor
+  belonging-need-satisfaction + my-actual-discounted-satisfaction-gain-for-belonging-needs-after-having-played current-activity-descriptor
   if belonging-need-satisfaction > 1 [set belonging-need-satisfaction 1]
   
   set compliance-need-satisfaction compliance-need-satisfaction +
@@ -59,6 +59,39 @@ to-report expected-undiscounted-belonging-needs-satisfaction-increase-for-playin
   let motive last activity-descriptor
   
   let number [expected-number-of-other-participants] of gp
+  let base 0
+  let network-bonus 1
+  ;show (sentence "expected shift satisfaction community:"
+  ;   [gathering-type] of first activity-descriptor last activity-descriptor number)
+  ifelse number = 0 
+  [set base 0]
+  [ifelse number < 5
+    [set base 0.05]
+    [ifelse number < 20
+      [set base 0.1]
+      [set base 0.25]
+    ]
+  ]
+  let family-present any? (([gatherers] of gp) with [member? self [my-relatives] of myself])
+  if family-present and days-since-seen-relatives > 0 [
+    set network-bonus network-bonus + min (list 0.5 (days-since-seen-relatives / 28))
+  ]
+  let colleagues-present any? (([gatherers] of gp) with [member? self [my-colleagues] of myself])
+  if colleagues-present and days-since-seen-colleagues > 0 [
+    set network-bonus network-bonus + min (list 0.5 (days-since-seen-colleagues / 28))
+  ]
+  let friends-present any? (([gatherers] of gp) with [member? self [my-friends] of myself])
+  if friends-present and days-since-seen-friends > 0 [
+    set network-bonus network-bonus + min (list 0.5 (days-since-seen-friends / 28))
+  ]
+  report base * network-bonus
+end
+
+to-report actual-undiscounted-belonging-needs-satisfaction-increase-for-playing [activity-descriptor]
+  let gp first activity-descriptor
+  let motive last activity-descriptor
+  
+  let number count people with [current-activity = gp]
   let base 0
   let network-bonus 1
   ;show (sentence "expected shift satisfaction community:"
@@ -309,6 +342,12 @@ to-report my-expected-discounted-satisfaction-gain-for-survival-after-having-pla
 end
 
 to-report  my-expected-discounted-satisfaction-gain-for-belonging-needs-after-having-played [activity-descriptor]
+  let expected-increase expected-undiscounted-belonging-needs-satisfaction-increase-for-playing activity-descriptor
+  let discounted-increase expected-increase * (1 - belonging-need-satisfaction)
+  report discounted-increase
+end
+
+to-report  my-actual-discounted-satisfaction-gain-for-belonging-needs-after-having-played [activity-descriptor]
   let expected-increase expected-undiscounted-belonging-needs-satisfaction-increase-for-playing activity-descriptor
   let discounted-increase expected-increase * (1 - belonging-need-satisfaction)
   report discounted-increase

--- a/people_activity.nls
+++ b/people_activity.nls
@@ -47,13 +47,8 @@ to perform-activity
       set heading towards current-activity
     ]
     
-    
-
-    execute-activity-effect
-    
-    update-needs-for-playing (list current-activity current-motivation)
-    ]
-    [error "not implemented"]
+  ]
+  [error "not implemented"]
 end
 
 to-report is-I-have-contractual-obligations?

--- a/people_decision.nls
+++ b/people_decision.nls
@@ -104,7 +104,7 @@ end
 
 
 to-report is-allowed-to-work-from-home?
-  report true
+  report member? [gathering-type] of my-work ["workplace" "university"]
   ;link-neighbors with [gathering-type = "workplace"]
 end
 

--- a/people_management.nls
+++ b/people_management.nls
@@ -452,12 +452,14 @@ to relate-person-to-gathering-points
         [ set commitment 1
           set features (list "getting money" "contractual obligation")
         ]
+        stop
       ]
       if random-float 1 < probability-university-personel [
         create-gathering-link-to one-of gathering-points with [gathering-type = "university"]
         [ set commitment 1
           set features (list "getting money" "contractual obligation")
         ]
+        stop
       ]
       if random-float 1 < probability-shopkeeper [
         ask one-of my-out-gathering-links with [member? "shopping" features] [


### PR DESCRIPTION
This pull request does two things:

First of all, it split out agents selecting an action and moving there from updating the agents internal state. This makes it possible to update the agents state based on the actual state of the simulation, not the state the agents will expect it to be in (already changed for belonging)

Secondly, it recalibrated the agents needs in such a way that the agents move around less during the working day, so they are more likely to stay in school and at work. 