### PR TITLE
removed age-model input because non existing anymore

### DIFF
--- a/environment_dynamics.nls
+++ b/environment_dynamics.nls
@@ -1,1 +1,1 @@
- __includes ["contagion.nls" "gathering_points.nls" "public_measures.nls" "general_environment_dynamics.nls" "activity_model.nls" "people_age_model.nls" "disease_model.nls" "economy_model.nls"]
+ __includes ["contagion.nls" "gathering_points.nls" "public_measures.nls" "general_environment_dynamics.nls" "activity_model.nls"  "disease_model.nls" "economy_model.nls"]


### PR DESCRIPTION
Apparently the age-model file does not exist anymore. Therefore I removed the input command from a file in order to make it possible that model is running again. See current issue tracker.