### PR TITLE
Setup scenario 9

### DIFF
--- a/simulation_model/activity_model.nls
+++ b/simulation_model/activity_model.nls
@@ -288,6 +288,26 @@ end
 
 to perform-people-activities
   reset-timer
+  
+  if food-delivery-for-isolators? [
+    ask homes-in-isolation [
+      ; Find the store with the most stocks
+      let possible-stores reduce [[x y] -> (turtle-set x y)] [my-essential-shops] of gatherers 
+      let store max-one-of possible-stores [stock-of-goods]
+      ; Find the inhabitant with the most money
+      let buyer max-one-of gatherers [my-amount-of-capital]
+      let old-location [current-activity] of buyer
+      let old-motive [current-motivation] of buyer
+      ; Fake going to the store this round (internet order?)
+      ask buyer [ 
+        set current-activity store
+        set current-motivation "essential shopping"
+        update-resources-based-on-current-activity
+        set current-activity old-location
+        set current-motivation old-motive
+      ]
+    ]
+  ]
 
   ask people [
     if not is-being-away? current-activity and current-motivation = travelling-motive [error "wrong place while travelling"]

--- a/simulation_model/activity_model.nls
+++ b/simulation_model/activity_model.nls
@@ -291,6 +291,7 @@ to perform-people-activities
   
   if food-delivery-for-isolators? [
     ask homes-in-isolation [
+      if available-food-rations / [amount-of-rations-I-buy-when-going-to-essential-shops] of one-of gatherers >= 1 [stop]
       ; Find the store with the most stocks
       let possible-stores reduce [[x y] -> (turtle-set x y)] [my-essential-shops] of gatherers 
       let store max-one-of possible-stores [stock-of-goods]

--- a/simulation_model/covid-sim.nlogo
+++ b/simulation_model/covid-sim.nlogo
@@ -266,7 +266,7 @@ density-factor-universities
 density-factor-universities
 0
 1
-0.2
+0.21
 0.01
 1
 NIL
@@ -281,7 +281,7 @@ density-factor-workplaces
 density-factor-workplaces
 0
 1
-0.21
+0.23
 0.01
 1
 NIL
@@ -296,7 +296,7 @@ density-factor-public-leisure
 density-factor-public-leisure
 0
 1
-0.51
+0.88
 0.01
 1
 NIL
@@ -311,7 +311,7 @@ density-factor-private-leisure
 density-factor-private-leisure
 0
 1
-0.19
+0.21
 0.01
 1
 NIL
@@ -354,9 +354,9 @@ global-confinement-measures
 
 PLOT
 10
-680
+681
 518
-830
+831
 measures
 NIL
 NIL
@@ -417,7 +417,7 @@ density-factor-essential-shops
 density-factor-essential-shops
 0
 1
-0.19
+0.22
 0.01
 1
 NIL
@@ -469,7 +469,7 @@ density-factor-hospital
 density-factor-hospital
 0
 1
-0.81
+0.82
 0.01
 1
 NIL
@@ -484,7 +484,7 @@ probability-hospital-personel
 probability-hospital-personel
 0
 1
-0.04
+0.026
 0.01
 1
 NIL
@@ -499,7 +499,7 @@ probability-school-personel
 probability-school-personel
 0
 1
-0.03
+0.034
 0.01
 1
 NIL
@@ -592,9 +592,9 @@ NIL
 
 BUTTON
 10
-168
+206
 105
-203
+241
 1 Week Run
 go\nwhile [day-of-the-week != \"monday\" or slice-of-the-day != \"morning\"] [go]
 NIL
@@ -981,7 +981,7 @@ count people with [[gathering-type] of current-activity = \"hospital\"]
 PLOT
 10
 834
-521
+518
 1153
 Average need satisfaction
 time
@@ -1459,25 +1459,25 @@ household-profiles
 2
 
 SLIDER
-1931
-745
-2225
-778
+1929
+635
+2216
+668
 ratio-population-randomly-tested-daily
 ratio-population-randomly-tested-daily
 0
 1
-0.0
+0.05
 0.01
 1
 NIL
 HORIZONTAL
 
 SWITCH
-1928
-822
-2222
-855
+1929
+709
+2219
+742
 test-workplace-of-confirmed-people?
 test-workplace-of-confirmed-people?
 1
@@ -1485,10 +1485,10 @@ test-workplace-of-confirmed-people?
 -1000
 
 SWITCH
-1931
-782
-2224
-815
+1929
+672
+2218
+705
 test-home-of-confirmed-people?
 test-home-of-confirmed-people?
 1
@@ -1496,10 +1496,10 @@ test-home-of-confirmed-people?
 -1000
 
 TEXTBOX
-1931
-720
-2081
-738
+1929
+610
+2079
+628
 Testing
 11
 105.0
@@ -1875,7 +1875,7 @@ starting-amount-of-capital-workers
 starting-amount-of-capital-workers
 0
 100
-75.0
+76.0
 1
 1
 NIL
@@ -2091,7 +2091,7 @@ mean-social-distance-profile
 mean-social-distance-profile
 0
 1
-0.25
+0.29
 0.01
 1
 NIL
@@ -2103,7 +2103,7 @@ INPUTBOX
 644
 425
 #households
-100.0
+400.0
 1
 0
 Number
@@ -2681,9 +2681,9 @@ NIL
 
 BUTTON
 10
-210
+248
 102
-245
+283
 1 Month Run
 let starting-day current-day\nlet end-day starting-day + 28\nwhile [current-day <= end-day] [ go ]
 NIL
@@ -2704,7 +2704,7 @@ CHOOSER
 set_national_culture
 set_national_culture
 "Custom" "Belgium" "Canada" "Germany" "Great Britain" "France" "Italy" "Korea South" "Netherlands" "Norway" "Spain" "Singapore" "Sweden" "U.S.A."
-5
+6
 
 SLIDER
 2364
@@ -2715,7 +2715,7 @@ uncertainty-avoidance
 uncertainty-avoidance
 0
 100
-86.0
+75.0
 1
 1
 NIL
@@ -2730,7 +2730,7 @@ individualism-vs-collectivism
 individualism-vs-collectivism
 0
 100
-71.0
+76.0
 1
 1
 NIL
@@ -2745,7 +2745,7 @@ power-distance
 power-distance
 0
 100
-68.0
+50.0
 1
 1
 NIL
@@ -2760,7 +2760,7 @@ indulgence-vs-restraint
 indulgence-vs-restraint
 0
 100
-48.0
+30.0
 1
 1
 NIL
@@ -2775,7 +2775,7 @@ masculinity-vs-femininity
 masculinity-vs-femininity
 0
 100
-43.0
+70.0
 1
 1
 NIL
@@ -2790,7 +2790,7 @@ long-vs-short-termism
 long-vs-short-termism
 0
 100
-63.0
+61.0
 1
 1
 NIL
@@ -2903,7 +2903,7 @@ SWITCH
 1166
 is-working-from-home-recommended?
 is-working-from-home-recommended?
-0
+1
 1
 -1000
 
@@ -2957,9 +2957,9 @@ NIL
 
 BUTTON
 10
-250
+288
 103
-285
+323
 go once
 go
 NIL
@@ -2974,9 +2974,9 @@ NIL
 
 BUTTON
 10
-290
+328
 101
-323
+361
 inspect person
 inspect one-of people
 NIL
@@ -3121,7 +3121,7 @@ percentage-of-agents-with-random-link
 percentage-of-agents-with-random-link
 0
 1
-0.1
+0.14
 0.01
 1
 NIL
@@ -3583,6 +3583,140 @@ r0
 17
 1
 11
+
+INPUTBOX
+2367
+850
+2458
+910
+#available-tests
+50.0
+1
+0
+Number
+
+SWITCH
+1929
+746
+2220
+779
+prioritize-testing-health-care-and-eduction?
+prioritize-testing-health-care-and-eduction?
+0
+1
+-1000
+
+BUTTON
+12
+168
+104
+201
+1 Day run
+if slice-of-the-day = \"morning\" [go]\nwhile [slice-of-the-day != \"morning\"] [go]
+NIL
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+SWITCH
+1928
+784
+2220
+817
+do-not-test-youth?
+do-not-test-youth?
+0
+1
+-1000
+
+SWITCH
+1928
+823
+2222
+856
+only-test-retirees-with-extra-tests?
+only-test-retirees-with-extra-tests?
+1
+1
+-1000
+
+SWITCH
+1607
+1254
+1853
+1287
+ask-the-sick-and-family-to-stay-home?
+ask-the-sick-and-family-to-stay-home?
+0
+1
+-1000
+
+MONITOR
+1759
+1340
+1854
+1385
+non isolators
+count should-be-isolators with [current-activity != my-home and current-activity != my-hospital and current-activity != away-gathering-point]
+17
+1
+11
+
+MONITOR
+1639
+1340
+1755
+1385
+Should be isolating
+count should-be-isolators
+17
+1
+11
+
+SWITCH
+1607
+1293
+1854
+1326
+food-delivery-for-isolators?
+food-delivery-for-isolators?
+0
+1
+-1000
+
+PLOT
+1088
+1180
+1576
+1330
+Self-isolation
+time
+#people
+0.0
+10.0
+0.0
+10.0
+true
+true
+"" ""
+PENS
+"Should be isolating" 1.0 0 -16777216 true "" "plot count should-be-isolators"
+"Breaking isolation" 1.0 0 -13345367 true "" "plot count should-be-isolators with [current-activity != my-home and current-activity != my-hospital and current-activity != away-gathering-point]"
+
+TEXTBOX
+1678
+1227
+1828
+1245
+Self-isolation
+11
+105.0
+1
 
 @#$#@#$#@
 ## WHAT IS IT?

--- a/simulation_model/covid-sim.nlogo
+++ b/simulation_model/covid-sim.nlogo
@@ -499,7 +499,7 @@ probability-school-personel
 probability-school-personel
 0
 1
-0.034
+0.028
 0.01
 1
 NIL
@@ -514,7 +514,7 @@ probability-university-personel
 probability-university-personel
 0
 1
-0.03
+0.005
 0.01
 1
 NIL
@@ -1467,7 +1467,7 @@ ratio-population-randomly-tested-daily
 ratio-population-randomly-tested-daily
 0
 1
-0.05
+0.0
 0.01
 1
 NIL
@@ -1588,7 +1588,7 @@ CHOOSER
 134
 preset-scenario
 preset-scenario
-"default-scenario" "scenario-1-zero-action-scandinavia" "scenario-1-closing-schools-and-uni" "scenario-1-work-at-home-only" "scenario-1-closing-all" "scenario-3-random-test-20" "scenario-3-app-test-60" "scenario-3-app-test-80" "scenario-3-app-test-100" "economic-scenario-1-baseline" "economic-scenario-2-infections" "economic-scenario-3-lockdown" "economic-scenario-4-wages" "app-test-scenario-5-1K" "no-action-scandinavia-2.5K" "one-family"
+"default-scenario" "scenario-1-zero-action-scandinavia" "scenario-1-closing-schools-and-uni" "scenario-1-work-at-home-only" "scenario-1-closing-all" "scenario-3-random-test-20" "scenario-3-app-test-60" "scenario-3-app-test-80" "scenario-3-app-test-100" "economic-scenario-1-baseline" "economic-scenario-2-infections" "economic-scenario-3-lockdown" "economic-scenario-4-wages" "app-test-scenario-5-1K" "no-action-scandinavia-2.5K" "one-family" "scenario-9-smart-testing"
 0
 
 MONITOR
@@ -1875,7 +1875,7 @@ starting-amount-of-capital-workers
 starting-amount-of-capital-workers
 0
 100
-76.0
+75.0
 1
 1
 NIL
@@ -2103,7 +2103,7 @@ INPUTBOX
 644
 425
 #households
-400.0
+100.0
 1
 0
 Number
@@ -2125,7 +2125,7 @@ INPUTBOX
 1570
 348
 #beds-in-hospital
-13.0
+10.0
 1
 0
 Number
@@ -3363,7 +3363,7 @@ SWITCH
 477
 make-social-distance-profile-value-based?
 make-social-distance-profile-value-based?
-0
+1
 1
 -1000
 
@@ -3602,7 +3602,7 @@ SWITCH
 779
 prioritize-testing-health-care-and-eduction?
 prioritize-testing-health-care-and-eduction?
-0
+1
 1
 -1000
 
@@ -3630,7 +3630,7 @@ SWITCH
 817
 do-not-test-youth?
 do-not-test-youth?
-0
+1
 1
 -1000
 
@@ -3652,7 +3652,7 @@ SWITCH
 1287
 ask-the-sick-and-family-to-stay-home?
 ask-the-sick-and-family-to-stay-home?
-0
+1
 1
 -1000
 
@@ -3685,7 +3685,7 @@ SWITCH
 1326
 food-delivery-for-isolators?
 food-delivery-for-isolators?
-0
+1
 1
 -1000
 

--- a/simulation_model/covid-sim.nlogo
+++ b/simulation_model/covid-sim.nlogo
@@ -3497,25 +3497,25 @@ NIL
 HORIZONTAL
 
 SLIDER
-2026
-698
-2213
-731
+1861
+1387
+2048
+1420
 ratio-young-with-phones
 ratio-young-with-phones
 0
 1
-0.1
+0.11
 0.01
 1
 NIL
 HORIZONTAL
 
 SLIDER
-2026
-666
-2215
-699
+1861
+1423
+2050
+1456
 ratio-retired-with-phones
 ratio-retired-with-phones
 0
@@ -3527,10 +3527,10 @@ NIL
 HORIZONTAL
 
 MONITOR
-2233
-647
-2342
-692
+2059
+1387
+2168
+1432
 #phone-owners
 count people with [has-mobile-phone?]
 17
@@ -3538,10 +3538,10 @@ count people with [has-mobile-phone?]
 11
 
 MONITOR
-2233
-691
-2342
-736
+2059
+1431
+2168
+1476
 ratio-phone-owners
 count people with [has-mobile-phone?] / count people
 17

--- a/simulation_model/covid-sim.nlogo
+++ b/simulation_model/covid-sim.nlogo
@@ -163,7 +163,7 @@ INPUTBOX
 938
 700
 #schools-gp
-3.0
+2.0
 1
 0
 Number
@@ -174,7 +174,7 @@ INPUTBOX
 1031
 700
 #universities-gp
-10.0
+1.0
 1
 0
 Number
@@ -185,7 +185,7 @@ INPUTBOX
 1123
 702
 #workplaces-gp
-10.0
+34.0
 1
 0
 Number
@@ -206,7 +206,7 @@ INPUTBOX
 1239
 702
 #public-leisure-gp
-1.0
+3.0
 1
 0
 Number
@@ -217,7 +217,7 @@ INPUTBOX
 1358
 702
 #private-leisure-gp
-10.0
+34.0
 1
 0
 Number
@@ -403,7 +403,7 @@ INPUTBOX
 1479
 702
 #essential-shops-gp
-5.0
+17.0
 1
 0
 Number
@@ -444,7 +444,7 @@ INPUTBOX
 1636
 702
 #non-essential-shops-gp
-10.0
+34.0
 1
 0
 Number
@@ -455,7 +455,7 @@ INPUTBOX
 851
 700
 #hospital-gp
-1.0
+3.0
 1
 0
 Number
@@ -904,7 +904,7 @@ SWITCH
 620
 migration?
 migration?
-0
+1
 1
 -1000
 
@@ -1082,7 +1082,7 @@ ratio-family-homes
 ratio-family-homes
 0
 1
-0.371
+0.344
 0.01
 1
 NIL
@@ -1180,7 +1180,7 @@ ratio-adults-homes
 ratio-adults-homes
 0
 1
-0.278
+0.309
 0.01
 1
 NIL
@@ -1195,7 +1195,7 @@ ratio-retired-couple-homes
 ratio-retired-couple-homes
 0
 1
-0.315
+0.298
 0.01
 1
 NIL
@@ -1210,7 +1210,7 @@ ratio-multi-generational-homes
 ratio-multi-generational-homes
 0
 1
-0.036
+0.049
 0.01
 1
 NIL
@@ -1456,7 +1456,7 @@ CHOOSER
 household-profiles
 household-profiles
 "none" "Custom" "Belgium" "Canada" "Germany" "Great Britain" "France" "Italy" "Korea South" "Netherlands" "Norway" "Spain" "Singapore" "Sweden" "U.S.A."
-2
+7
 
 SLIDER
 1929
@@ -1577,7 +1577,7 @@ SWITCH
 81
 static-seed?
 static-seed?
-0
+1
 1
 -1000
 
@@ -1589,7 +1589,7 @@ CHOOSER
 preset-scenario
 preset-scenario
 "default-scenario" "scenario-1-zero-action-scandinavia" "scenario-1-closing-schools-and-uni" "scenario-1-work-at-home-only" "scenario-1-closing-all" "scenario-3-random-test-20" "scenario-3-app-test-60" "scenario-3-app-test-80" "scenario-3-app-test-100" "economic-scenario-1-baseline" "economic-scenario-2-infections" "economic-scenario-3-lockdown" "economic-scenario-4-wages" "app-test-scenario-5-1K" "no-action-scandinavia-2.5K" "one-family" "scenario-9-smart-testing"
-0
+16
 
 MONITOR
 743
@@ -2103,7 +2103,7 @@ INPUTBOX
 644
 425
 #households
-100.0
+345.0
 1
 0
 Number
@@ -2125,7 +2125,7 @@ INPUTBOX
 1570
 348
 #beds-in-hospital
-10.0
+11.0
 1
 0
 Number
@@ -3363,7 +3363,7 @@ SWITCH
 477
 make-social-distance-profile-value-based?
 make-social-distance-profile-value-based?
-1
+0
 1
 -1000
 
@@ -3602,7 +3602,7 @@ SWITCH
 779
 prioritize-testing-health-care-and-eduction?
 prioritize-testing-health-care-and-eduction?
-1
+0
 1
 -1000
 
@@ -3630,7 +3630,7 @@ SWITCH
 817
 do-not-test-youth?
 do-not-test-youth?
-1
+0
 1
 -1000
 
@@ -3652,7 +3652,7 @@ SWITCH
 1287
 ask-the-sick-and-family-to-stay-home?
 ask-the-sick-and-family-to-stay-home?
-1
+0
 1
 -1000
 
@@ -3685,7 +3685,7 @@ SWITCH
 1326
 food-delivery-for-isolators?
 food-delivery-for-isolators?
-1
+0
 1
 -1000
 

--- a/simulation_model/epistemic_model.nls
+++ b/simulation_model/epistemic_model.nls
@@ -36,7 +36,11 @@ to-report is-believing-to-be-infected?
 end
 
 to perform-test
+  ; Make sure we don't do more tests than available
+  if #still-available-tests <= 0 [stop]
+  
   set #tests-performed #tests-performed + 1
+  set #tests-done-today #tests-done-today + 1
   
   if not is-infected? and is-believing-to-be-infected? [set epistemic-infection-status "immune"]
   if is-infected? [

--- a/simulation_model/gathering_points.nls
+++ b/simulation_model/gathering_points.nls
@@ -332,3 +332,14 @@ end
 to-report is-family-present-in-current-gathering-point?
   report any? my-relatives with [current-activity = [current-activity] of myself]
 end
+
+to-report home-in-isolation?
+  if not is-home? or not ask-the-sick-and-family-to-stay-home? [
+    report false
+  ]
+  report any? gatherers with [is-believing-to-be-infected?]
+end
+
+to-report homes-in-isolation
+  report homes with [home-in-isolation?]
+end

--- a/simulation_model/need_management.nls
+++ b/simulation_model/need_management.nls
@@ -216,13 +216,18 @@ to-report SUA-risk-avoidance [ad]
   report risk-avoidance-increase ad count people with [current-activity = gp]
 end
 
+to-report should-I-stay-home?
+  if is-lockdown-enforced? [report true]
+  if ask-the-sick-and-family-to-stay-home? and [home-in-isolation?] of my-home [report true]
+  report false
+end
+
 to-report SUE-compliance [ad]
   let gp location-of ad
   let motive motive-of ad
 
   let bonus-compliance-to-obligation 0
-  if gp = my-home and is-lockdown-enforced?
-  [
+  if gp = my-home and should-I-stay-home? [
   ;  show "lockdown bonus"
     set bonus-compliance-to-obligation  bonus-compliance-to-obligation + 0.2
   ]
@@ -236,7 +241,7 @@ to-report SUE-compliance [ad]
   if (motive = work-motive) and is-I-have-contractual-obligations?
   [
 ;    show "do your work bonus"
-    if not is-lockdown-enforced? and gp != my-home [
+    if not should-I-stay-home? and gp != my-home [
       set bonus-compliance-to-obligation bonus-compliance-to-obligation + 0.2
       if gp = current-activity [
         set bonus-compliance-to-obligation  bonus-compliance-to-obligation + 0.2
@@ -249,7 +254,7 @@ to-report SUE-compliance [ad]
   ]
 
   ; Make kids go to school
-  ifelse (motive = "mandatory") and not is-lockdown-enforced? [
+  ifelse (motive = "mandatory") and not should-I-stay-home? [
     set bonus-compliance-to-obligation bonus-compliance-to-obligation + 0.1
   ] [
     if age = "youth" [
@@ -258,19 +263,19 @@ to-report SUE-compliance [ad]
   ]
 
   ; Make students go to university
-  if (motive = "learning") and not is-lockdown-enforced? [
+  if (motive = "learning") and not should-I-stay-home? [
     set bonus-compliance-to-obligation bonus-compliance-to-obligation + 0.1
   ]
 
-  if is-lockdown-enforced? and gp != my-home [
+  if should-I-stay-home? and gp != my-home [
     set bonus-compliance-to-obligation bonus-compliance-to-obligation - 0.2
   ]
 
-  if not is-lockdown-enforced? and member? motive ["relaxing" "shopping"] [
+  if not should-I-stay-home? and member? motive ["relaxing" "shopping"] [
     set bonus-compliance-to-obligation bonus-compliance-to-obligation + 0.1
   ]
 
-  if not is-lockdown-enforced? and age = "retired" and slice-of-the-day = "morning" and [gathering-type] of gp = "relaxing" [
+  if not should-I-stay-home? and age = "retired" and slice-of-the-day = "morning" and [gathering-type] of gp = "relaxing" [
     ; Make retired agents do something relaxing every morning
     set bonus-compliance-to-obligation bonus-compliance-to-obligation + 0.1
   ]
@@ -306,6 +311,9 @@ to-report SUE-leisure [ad]
 
   if motive = "relaxing" [
     report 0.4
+  ]
+  if gp = my-home and motive = "rest" [
+    report 0.1
   ]
   report 0
 end
@@ -395,16 +403,26 @@ to-report SUE-financial-survival [ad]
     let eating-costs price-of-rations-in-essential-shops * amount-of-rations-I-buy-when-going-to-essential-shops
     
     if is-I-have-contractual-obligations? [
-      if gp = my-work [
+      if gp = my-work and is-working-motive? motive [
         report min (list (my-expected-income / eating-costs) 1)
       ]
       report max (list ((- my-expected-income) / eating-costs) 0)
     ]
     if motive = "essential shopping" [
-      report (- min (list ((my-amount-of-capital - eating-costs) / eating-costs) 1))
+      let money-left-over my-amount-of-capital - eating-costs
+      ; If we spend all our money, financial-survival will drop to 0
+      if money-left-over < 0 [
+        report (- financial-survival-satisfaction-level)
+      ]
+      report (- min (list (money-left-over / eating-costs) 1))
     ]
     if motive = "shopping" [
-      report (- min (list ((my-amount-of-capital - amount-of-rations-I-buy-when-going-to-shops * price-of-rations-in-non-essential-shops) / eating-costs) 1))
+      let money-left-over my-amount-of-capital - amount-of-rations-I-buy-when-going-to-shops * price-of-rations-in-non-essential-shops
+      ; If we spend all our money, financial-survival will drop to 0
+      if money-left-over < 0 [
+        report (- financial-survival-satisfaction-level)
+      ]
+      report (- min (list (money-left-over / eating-costs) 1))
     ]
     report 0
   ]
@@ -436,7 +454,6 @@ to-report SUE-financial-safety [ad]
   report 0
 end
 
-
 to-report SUE-health [ad]
   let base 1
   let sd-bonus 0.8
@@ -451,9 +468,9 @@ to-report SUE-health [ad]
       [set base 0]
     ] [
       ifelse is-get-healed-to-hospital-descriptor? ad and (is-currently-allocated-a-bed-in-hospital? or any-free-bed-in-hospital?)
-      [set base .6]
+      [set base .3]
       [ ifelse is-rest-at-home-descriptor? ad
-        [ set base 0.2 ]
+        [ set base 0.3 ]
         [ set base -0.1 ]
       ]
     ]
@@ -519,29 +536,33 @@ to-report global-prevalence-of [ad]
 end
 
 to debug-global-prevalence-of [ad]
-  debug-print (sentence [gathering-type] of (location-of ad) " " motive-of ad " " social-distancing-of ad) 
-    ;Survival needs
-  debug-print (word "  Food Safety:" (SDE-food-safety ad * importance-weight-food-safety))
-  debug-print (word "  Financial-survival:" (SDE-financial-survival ad * importance-weight-financial-survival))
-  debug-print (word "  Sleep:" (SDE-sleep ad * importance-weight-sleep))
-  debug-print (word "  Health:" (SDE-health ad * importance-weight-health))
-  debug-print (word "  Conformity:" (SDE-conformity ad * importance-weight-conformity))
-    ;Safety needs
-  debug-print (word "  Compliance:" (SDE-compliance ad * importance-weight-compliance))
-  debug-print (word "  Risk Avoidance:" (SDE-risk-avoidance ad * importance-weight-risk-avoidance))
-  debug-print (word "  Financial Safety:" (SDE-financial-safety ad * importance-weight-financial-safety))
-    ;Belonging needs
-  debug-print (word "  Belonging:" (SDE-belonging ad * importance-weight-belonging-subneed))
-    ;Esteem needs
-  debug-print (word "  Autonomy:" (SDE-autonomy ad * importance-weight-autonomy))
-  debug-print (word "  Luxury:" (SDE-luxury ad * importance-weight-luxury))
-  debug-print (word "  Leisure:" (SDE-leisure ad * importance-weight-leisure))
-  
-  debug-print (word " Global:" global-prevalence-of ad)
+  if debug? [
+    debug-print (sentence [gathering-type] of (location-of ad) " " motive-of ad " " social-distancing-of ad) 
+      ;Survival needs
+    debug-print (word "  Food Safety:" (SDE-food-safety ad * importance-weight-food-safety))
+    debug-print (word "  Financial-survival:" (SDE-financial-survival ad * importance-weight-financial-survival))
+    debug-print (word "  Sleep:" (SDE-sleep ad * importance-weight-sleep))
+    debug-print (word "  Health:" (SDE-health ad * importance-weight-health))
+    debug-print (word "  Conformity:" (SDE-conformity ad * importance-weight-conformity))
+      ;Safety needs
+    debug-print (word "  Compliance:" (SDE-compliance ad * importance-weight-compliance))
+    debug-print (word "  Risk Avoidance:" (SDE-risk-avoidance ad * importance-weight-risk-avoidance))
+    debug-print (word "  Financial Safety:" (SDE-financial-safety ad * importance-weight-financial-safety))
+      ;Belonging needs
+    debug-print (word "  Belonging:" (SDE-belonging ad * importance-weight-belonging-subneed))
+      ;Esteem needs
+    debug-print (word "  Autonomy:" (SDE-autonomy ad * importance-weight-autonomy))
+    debug-print (word "  Luxury:" (SDE-luxury ad * importance-weight-luxury))
+    debug-print (word "  Leisure:" (SDE-leisure ad * importance-weight-leisure))
+    
+    debug-print (word " Global:" global-prevalence-of ad)
+  ]
 end
 
 to debug-my-preferred-available-activity-descriptor
-  foreach my-available-activity-descriptors debug-global-prevalence-of 
+  if debug? [
+    foreach my-available-activity-descriptors debug-global-prevalence-of
+  ]
 end
 
 ;;; SDE and SDA SURVIVAL NEEDS

--- a/simulation_model/public_measures.nls
+++ b/simulation_model/public_measures.nls
@@ -127,6 +127,7 @@ to disable-all-measures
   ; Testing
   set ratio-population-randomly-tested-daily 0
   set ratio-population-daily-immunity-testing 0
+  set available-tests 10000
   set test-home-of-confirmed-people? false
   set test-workplace-of-confirmed-people? false
   set prioritize-testing-health-care-and-eduction? false

--- a/simulation_model/public_measures.nls
+++ b/simulation_model/public_measures.nls
@@ -41,36 +41,36 @@ to perform-testing
   if slice-of-the-day = "afternoon" [
     set #tests-done-today 0
     let prioritized-people (turtle-set nobody)
-    
+
     if prioritize-testing-health-care-and-eduction? [
       set prioritized-people (turtle-set prioritized-people (workers with [[is-hospital?] of my-work]))
       set prioritized-people (turtle-set prioritized-people (workers with [[is-school? or is-university?] of my-work]))
     ]
-    
+
     ask up-to-n-of #still-available-tests prioritized-people [
       perform-test
     ]
-    
+
     ; Make sure we do not test people twice
     let people-to-test people with [not member? self prioritized-people]
-    
+
     if do-not-test-youth? [
       set people-to-test people-to-test with [not is-young?]
     ]
-    
+
     if only-test-retirees-with-extra-tests? [
       set people-to-test retireds
     ]
-    
+
     ; We cannot test more people than we have tests available
-    let #people-to-test (min (list 
-      (ratio-population-randomly-tested-daily * count people) 
+    let #people-to-test (min (list
+      (ratio-population-randomly-tested-daily * count people)
       #still-available-tests))
-    
+
     ask n-of #people-to-test people-to-test [
       perform-test
     ]
-   
+
     ask n-of (ratio-population-daily-immunity-testing * count people) people [
       perform-immunity-test
     ]
@@ -114,6 +114,7 @@ to-report should-be-isolators
 end
 
 to disable-all-measures
+  ; Closing
   set ratio-omniscious-infected-that-trigger-school-closing-measure 1
   set ratio-omniscious-infected-that-trigger-social-distancing-measure 1
   set ratio-omniscious-infected-that-trigger-non-essential-closing-measure 1
@@ -121,9 +122,19 @@ to disable-all-measures
   set #days-trigger-non-essential-business-closing-measure 10000
   set is-closing-school-when-any-reported-case-measure? false
   set global-confinement-measures "none"
+  set closed-universities? false
+  set closed-workplaces? false
+  ; Testing
+  set ratio-population-randomly-tested-daily 0
+  set ratio-population-daily-immunity-testing 0
   set test-home-of-confirmed-people? false
   set test-workplace-of-confirmed-people? false
-  set ratio-population-randomly-tested-daily 0
-  set closed-universities? false
+  set prioritize-testing-health-care-and-eduction? false
+  set do-not-test-youth? false
+  set only-test-retirees-with-extra-tests? false
+  ; App settings
   set ratio-of-users-of-the-tracking-app 0
+  ; Isolation
+  set ask-the-sick-and-family-to-stay-home? false
+  set food-delivery-for-isolators? false
 end

--- a/simulation_model/public_measures.nls
+++ b/simulation_model/public_measures.nls
@@ -1,5 +1,6 @@
 globals [
   was-social-distancing-enforced?
+  #tests-done-today
 ]
 
 to-report is-lockdown-enforced?
@@ -35,19 +36,58 @@ to-report closed-schools?
   #days-trigger-school-closing-measure <= current-day
 end
 
-to apply-active-measures
-  ask n-of (ratio-population-randomly-tested-daily * count people) people [
-    perform-test
+to perform-testing
+  ; Only test once a day
+  if slice-of-the-day = "afternoon" [
+    set #tests-done-today 0
+    let prioritized-people (turtle-set nobody)
+    
+    if prioritize-testing-health-care-and-eduction? [
+      set prioritized-people (turtle-set prioritized-people (workers with [[is-hospital?] of my-work]))
+      set prioritized-people (turtle-set prioritized-people (workers with [[is-school? or is-university?] of my-work]))
+    ]
+    
+    ask up-to-n-of #still-available-tests prioritized-people [
+      perform-test
+    ]
+    
+    ; Make sure we do not test people twice
+    let people-to-test people with [not member? self prioritized-people]
+    
+    if do-not-test-youth? [
+      set people-to-test people-to-test with [not is-young?]
+    ]
+    
+    if only-test-retirees-with-extra-tests? [
+      set people-to-test retireds
+    ]
+    
+    ; We cannot test more people than we have tests available
+    let #people-to-test (min (list 
+      (ratio-population-randomly-tested-daily * count people) 
+      #still-available-tests))
+    
+    ask n-of #people-to-test people-to-test [
+      perform-test
+    ]
+   
+    ask n-of (ratio-population-daily-immunity-testing * count people) people [
+      perform-immunity-test
+    ]
   ]
+end
 
-  ask n-of (ratio-population-daily-immunity-testing * count people) people [
-    perform-immunity-test
-  ]
+to apply-active-measures
+  perform-testing
 
   if was-social-distancing-enforced? != is-social-distancing-measure-active? [
     set was-social-distancing-enforced? is-social-distancing-measure-active?
     inform-people-of-measures
   ]
+end
+
+to-report #still-available-tests
+  report #available-tests - #tests-done-today
 end
 
 to-report is-social-distancing-measure-active?
@@ -67,6 +107,10 @@ to inform-people-of-measures
     set I-know-of-social-distancing? true
     set I-know-of-working-from-home? true
   ]
+end
+
+to-report should-be-isolators
+  report people with [any? ([gatherers] of my-home) with [is-believing-to-be-infected?]]
 end
 
 to disable-all-measures

--- a/simulation_model/public_measures.nls
+++ b/simulation_model/public_measures.nls
@@ -127,7 +127,7 @@ to disable-all-measures
   ; Testing
   set ratio-population-randomly-tested-daily 0
   set ratio-population-daily-immunity-testing 0
-  set available-tests 10000
+  set #available-tests 10000
   set test-home-of-confirmed-people? false
   set test-workplace-of-confirmed-people? false
   set prioritize-testing-health-care-and-eduction? false

--- a/simulation_model/scenarios.nls
+++ b/simulation_model/scenarios.nls
@@ -177,14 +177,10 @@ end
 to scenario-9-setup
   load-baseline-scenario
   ; Set households and gathering points
-  set preset-profiles "none"
-  set ratio-adults-homes 0.31
-  set ratio-retired-couple-homes 0.23
-  set ratio-family-homes 0.23
-  set ratio-multi-generational-homes 0.01
+  set household-profiles "Italy"
   load-population-profile-based-on-current-preset-profile
   set set_national_culture "Italy"
-  load-scaled-values 300
+  load-scaled-values 345
   set #universities-gp 1
   set #schools-gp 2
   set migration? false

--- a/simulation_model/scenarios.nls
+++ b/simulation_model/scenarios.nls
@@ -98,6 +98,11 @@ to load-scenario-specifics
      load-scaled-values (1000 / 2.5)
     stop
   ]
+  if preset-scenario = "scenario-9-smart-testing"
+  [
+    scenario-9-setup
+    stop
+  ]
   error "unimplemented"
 end
 
@@ -169,7 +174,28 @@ to-report is-scenario-3? [s]
   report starts-with? s "scenario-3"
 end
   
-  
+to scenario-9-setup
+  load-baseline-scenario
+  ; Set households and gathering points
+  set preset-profiles "none"
+  set ratio-adults-homes 0.31
+  set ratio-retired-couple-homes 0.23
+  set ratio-family-homes 0.23
+  set ratio-multi-generational-homes 0.01
+  load-population-profile-based-on-current-preset-profile
+  set set_national_culture "Italy"
+  load-scaled-values 300
+  set #universities-gp 1
+  set #schools-gp 2
+  set migration? false
+  set probability-hospital-personel 0.026
+  set probability-school-personel 0.028
+  set probability-university-personel 0.005
+  set prioritize-testing-health-care-and-eduction? true
+  set do-not-test-youth? true
+  set ask-the-sick-and-family-to-stay-home? true
+  set food-delivery-for-isolators? true
+end
   
 
 to load-scaled-values [#hld]


### PR DESCRIPTION
This pull request adds quite a few new things to do with testing and soft measures.

1. Smarter testing:
    - Now you can prioritize the testing of health-care and education workers
    - Testing of young people can be turned off
    - A limit on available tests can be set
    - It is now possible to only test the elderly after the prioritized people
2. New soft measures:
    - Now agents that have sick housemates can be requested to stay at home
    - For these agents that are at home, food delivery at home is an option

The scenario itself can be set up by selecting `scenario-9-smart-testing` from the `preset-scenario` chooser.