### PR TITLE
update Behaviorspace scenario 7.1.4

### DIFF
--- a/simulation_model/covid-sim.nlogo
+++ b/simulation_model/covid-sim.nlogo
@@ -1896,10 +1896,10 @@ Social distancing
 1
 
 SLIDER
-2612
-1181
-2966
-1214
+2614
+1176
+2968
+1209
 ratio-omniscious-infected-that-trigger-social-distancing-measure
 ratio-omniscious-infected-that-trigger-social-distancing-measure
 0
@@ -1912,9 +1912,9 @@ HORIZONTAL
 
 MONITOR
 2612
-1246
+1250
 2798
-1291
+1295
 NIL
 is-social-distancing-measure-active?
 17
@@ -2205,9 +2205,9 @@ HORIZONTAL
 
 MONITOR
 2808
-1245
+1249
 2965
-1290
+1294
 #social-distancing
 count people with [is-I-apply-social-distancing? = true]
 17
@@ -4012,13 +4012,13 @@ ASSOCC\nincremental\nmodel\n(deprecated)
 1
 
 SWITCH
-2592
-1078
-2774
-1111
+2282
+1226
+2557
+1259
 is-working-from-home-recommended?
 is-working-from-home-recommended?
-0
+1
 1
 -1000
 
@@ -5684,7 +5684,7 @@ setup</setup>
       <value value="10000"/>
     </enumeratedValueSet>
   </experiment>
-  <experiment name="S7_1_3-no-public-measures" repetitions="10" runMetricsEveryStep="true">
+  <experiment name="S7_1_4-no-public-measures" repetitions="10" runMetricsEveryStep="true">
     <setup>load-scenario-7-cultural-model
 setup</setup>
     <go>go</go>
@@ -5698,6 +5698,7 @@ setup</setup>
     <metric>#tests-performed</metric>
     <metric>r0</metric>
     <metric>mean [social-distance-profile] of people</metric>
+    <metric>standard-deviation [social-distance-profile] of people</metric>
     <metric>count people with [I-know-of-social-distancing?]</metric>
     <metric>count people with [is-I-apply-social-distancing?]</metric>
     <metric>uncertainty-avoidance</metric>
@@ -5718,6 +5719,8 @@ setup</setup>
     <metric>count should-be-isolators with [current-activity != my-home and current-activity != my-hospital and current-activity != away-gathering-point]</metric>
     <metric>ratio-quarantiners-currently-complying-to-quarantine</metric>
     <metric>#contacts-last-tick</metric>
+    <metric>when-has-2%-infected-threshold-first-been-met?</metric>
+    <metric>when-has-5%-infected-threshold-first-been-met?</metric>
     <metric>#people-infected-in-hospitals</metric>
     <metric>#people-infected-in-workplaces</metric>
     <metric>#people-infected-in-homes</metric>
@@ -5751,6 +5754,7 @@ setup</setup>
     <metric>#cumulative-students-infector</metric>
     <metric>#cumulative-workers-infector</metric>
     <metric>#cumulative-retireds-infector</metric>
+    <metric>ratio-infected</metric>
     <metric>ratio-infected-youngs</metric>
     <metric>ratio-infected-students</metric>
     <metric>ratio-infected-workers</metric>
@@ -6251,7 +6255,7 @@ setup</setup>
       <value value="10000"/>
     </enumeratedValueSet>
   </experiment>
-  <experiment name="S7_1_3-only-social-distancing" repetitions="10" runMetricsEveryStep="true">
+  <experiment name="S7_1_4-only-social-distancing" repetitions="10" runMetricsEveryStep="true">
     <setup>load-scenario-7-cultural-model
 setup</setup>
     <go>go</go>
@@ -6265,6 +6269,7 @@ setup</setup>
     <metric>#tests-performed</metric>
     <metric>r0</metric>
     <metric>mean [social-distance-profile] of people</metric>
+    <metric>standard-deviation [social-distance-profile] of people</metric>
     <metric>count people with [I-know-of-social-distancing?]</metric>
     <metric>count people with [is-I-apply-social-distancing?]</metric>
     <metric>uncertainty-avoidance</metric>
@@ -6285,6 +6290,8 @@ setup</setup>
     <metric>count should-be-isolators with [current-activity != my-home and current-activity != my-hospital and current-activity != away-gathering-point]</metric>
     <metric>ratio-quarantiners-currently-complying-to-quarantine</metric>
     <metric>#contacts-last-tick</metric>
+    <metric>when-has-2%-infected-threshold-first-been-met?</metric>
+    <metric>when-has-5%-infected-threshold-first-been-met?</metric>
     <metric>#people-infected-in-hospitals</metric>
     <metric>#people-infected-in-workplaces</metric>
     <metric>#people-infected-in-homes</metric>
@@ -6318,6 +6325,7 @@ setup</setup>
     <metric>#cumulative-students-infector</metric>
     <metric>#cumulative-workers-infector</metric>
     <metric>#cumulative-retireds-infector</metric>
+    <metric>ratio-infected</metric>
     <metric>ratio-infected-youngs</metric>
     <metric>ratio-infected-students</metric>
     <metric>ratio-infected-workers</metric>
@@ -6818,7 +6826,7 @@ setup</setup>
       <value value="10000"/>
     </enumeratedValueSet>
   </experiment>
-  <experiment name="S7_1_3-social-distancing-lockdown" repetitions="10" runMetricsEveryStep="true">
+  <experiment name="S7_1_4-social-distancing-lockdown" repetitions="10" runMetricsEveryStep="true">
     <setup>load-scenario-7-cultural-model
 setup</setup>
     <go>go</go>
@@ -6832,6 +6840,7 @@ setup</setup>
     <metric>#tests-performed</metric>
     <metric>r0</metric>
     <metric>mean [social-distance-profile] of people</metric>
+    <metric>standard-deviation [social-distance-profile] of people</metric>
     <metric>count people with [I-know-of-social-distancing?]</metric>
     <metric>count people with [is-I-apply-social-distancing?]</metric>
     <metric>uncertainty-avoidance</metric>
@@ -6852,6 +6861,8 @@ setup</setup>
     <metric>count should-be-isolators with [current-activity != my-home and current-activity != my-hospital and current-activity != away-gathering-point]</metric>
     <metric>ratio-quarantiners-currently-complying-to-quarantine</metric>
     <metric>#contacts-last-tick</metric>
+    <metric>when-has-2%-infected-threshold-first-been-met?</metric>
+    <metric>when-has-5%-infected-threshold-first-been-met?</metric>
     <metric>#people-infected-in-hospitals</metric>
     <metric>#people-infected-in-workplaces</metric>
     <metric>#people-infected-in-homes</metric>
@@ -6885,6 +6896,7 @@ setup</setup>
     <metric>#cumulative-students-infector</metric>
     <metric>#cumulative-workers-infector</metric>
     <metric>#cumulative-retireds-infector</metric>
+    <metric>ratio-infected</metric>
     <metric>ratio-infected-youngs</metric>
     <metric>ratio-infected-students</metric>
     <metric>ratio-infected-workers</metric>
@@ -7385,7 +7397,7 @@ setup</setup>
       <value value="10000"/>
     </enumeratedValueSet>
   </experiment>
-  <experiment name="S7_1_3-social-distancing-tracking-tracing-testing-isolating" repetitions="10" runMetricsEveryStep="true">
+  <experiment name="S7_1_4-social-distancing-tracking-tracing-testing-isolating" repetitions="10" runMetricsEveryStep="true">
     <setup>load-scenario-7-cultural-model
 setup</setup>
     <go>go</go>
@@ -7399,6 +7411,7 @@ setup</setup>
     <metric>#tests-performed</metric>
     <metric>r0</metric>
     <metric>mean [social-distance-profile] of people</metric>
+    <metric>standard-deviation [social-distance-profile] of people</metric>
     <metric>count people with [I-know-of-social-distancing?]</metric>
     <metric>count people with [is-I-apply-social-distancing?]</metric>
     <metric>uncertainty-avoidance</metric>
@@ -7419,6 +7432,8 @@ setup</setup>
     <metric>count should-be-isolators with [current-activity != my-home and current-activity != my-hospital and current-activity != away-gathering-point]</metric>
     <metric>ratio-quarantiners-currently-complying-to-quarantine</metric>
     <metric>#contacts-last-tick</metric>
+    <metric>when-has-2%-infected-threshold-first-been-met?</metric>
+    <metric>when-has-5%-infected-threshold-first-been-met?</metric>
     <metric>#people-infected-in-hospitals</metric>
     <metric>#people-infected-in-workplaces</metric>
     <metric>#people-infected-in-homes</metric>
@@ -7452,6 +7467,7 @@ setup</setup>
     <metric>#cumulative-students-infector</metric>
     <metric>#cumulative-workers-infector</metric>
     <metric>#cumulative-retireds-infector</metric>
+    <metric>ratio-infected</metric>
     <metric>ratio-infected-youngs</metric>
     <metric>ratio-infected-students</metric>
     <metric>ratio-infected-workers</metric>

--- a/simulation_model/global_metrics.nls
+++ b/simulation_model/global_metrics.nls
@@ -3,6 +3,7 @@ globals
   #infected-times-ticks
   #delivered-supply-proposed-this-tick
   when-has-2%-infected-threshold-first-been-met?
+  when-has-5%-infected-threshold-first-been-met?
   #contacts-last-tick
   
   first-infected-people
@@ -97,6 +98,10 @@ to update-metrics
   
   if ratio-infected > 0.02 and when-has-2%-infected-threshold-first-been-met? = "never"
   [set when-has-2%-infected-threshold-first-been-met? ticks]
+
+  if ratio-infected > 0.05 and when-has-5%-infected-threshold-first-been-met? = "never"
+  [set when-has-5%-infected-threshold-first-been-met? ticks]
+
 end
 
 to reset-metrics
@@ -129,7 +134,7 @@ to reset-metrics
     
 end
 
-to increment-age-inection-information-metrics [infected infector]
+to increment-age-infection-information-metrics [infected infector]
   if [age = young-age] of infected [set #cumulative-youngs-infected #cumulative-youngs-infected + 1]
   if [age = student-age] of infected [set #cumulative-students-infected #cumulative-students-infected + 1]
   if [age = worker-age] of infected [set #cumulative-workers-infected #cumulative-workers-infected + 1]
@@ -187,7 +192,7 @@ end
 
 
 to increment-contagion-metrics-from [context infected infector]
-  increment-age-inection-information-metrics infected infector
+  increment-age-infection-information-metrics infected infector
   
   let key (list [age] of infector [age] of infected)
   table:put age-group-to-age-group-#infections-last-tick-table key table:get age-group-to-age-group-#infections-last-tick-table key + 1  

--- a/simulation_model/scenarios.nls
+++ b/simulation_model/scenarios.nls
@@ -342,6 +342,7 @@ to load-scaled-gathering-point-distribution [#hld]
   set #essential-shops-gp floor (#hld / 20)
   set #non-essential-shops-gp floor (#hld / 10)
   set #households #hld
+  set #bus-per-timeslot floor (#hld / 5)
 end
 
 to load-closed-schools-and-uni-measures

--- a/simulation_model/setup.nls
+++ b/simulation_model/setup.nls
@@ -29,6 +29,7 @@ to setup
   set list-of-dead-people []
   set was-social-distancing-enforced? false
   set when-has-2%-infected-threshold-first-been-met? "never"
+  set when-has-5%-infected-threshold-first-been-met? "never"
   set start-tick-of-global-quarantine "never"
 
   setup-activities
@@ -230,8 +231,8 @@ to setup-person [current-home l-age]
     set has-done-shopping false
     set stayed-out-queuing-for-bus? false
 
-    set I-know-of-social-distancing? true
-    set I-know-of-working-from-home? true
+    set I-know-of-social-distancing? false
+    set I-know-of-working-from-home? false
     set what-my-network-did-week-day []
     set what-my-network-did-weekend []
     set did-my-network-socially-distance? false


### PR DESCRIPTION
- updated behaviorspace settings for scenario 7
- changed default settings of knows-of-social-distancing? and knows-of-working-from-home? to **false** in the setup.nls (this is done because agents ought to only know about these measures if and only if these measures are actually implemented by the government)
- fixed scaling of the number of busses available to agent population